### PR TITLE
Add sonar-ping OLED animation during trackpad drag

### DIFF
--- a/keyboards/hidpress/bipedalambi/bipedalambi.c
+++ b/keyboards/hidpress/bipedalambi/bipedalambi.c
@@ -320,8 +320,8 @@ static void render_dissolve(uint8_t noise_level) {
 // edges, fading out over its lifetime. On release, in-flight rings finish
 // their expansion then normal rendering resumes.
 #define DRAG_NUM_RINGS          4
-#define DRAG_RING_LIFETIME_MS   900
-#define DRAG_RING_SPAWN_MS      300
+#define DRAG_RING_LIFETIME_MS   1800
+#define DRAG_RING_SPAWN_MS      600
 #define DRAG_RING_MAX_RADIUS    75
 #define DRAG_FRAME_MS           30
 

--- a/keyboards/hidpress/bipedalambi/bipedalambi.c
+++ b/keyboards/hidpress/bipedalambi/bipedalambi.c
@@ -5,6 +5,7 @@ enum pointing_device_mode current_mode = MODE_CUSTOM_KEYS;
 int actuation = 256;
 uint32_t actuation_display_timer = 0;
 bool showing_actuation = false;
+bool drag_active = false;
 
 #ifdef OLED_ENABLE
 #include "i2c_master.h"
@@ -313,6 +314,64 @@ static void render_dissolve(uint8_t noise_level) {
     }
 }
 
+// --- Drag sonar ping ---
+// While drag_active is true, a new ring is emitted from the OLED center every
+// DRAG_RING_SPAWN_MS. Each ring expands at constant speed past the screen
+// edges, fading out over its lifetime. On release, in-flight rings finish
+// their expansion then normal rendering resumes.
+#define DRAG_NUM_RINGS          4
+#define DRAG_RING_LIFETIME_MS   900
+#define DRAG_RING_SPAWN_MS      300
+#define DRAG_RING_MAX_RADIUS    75
+#define DRAG_FRAME_MS           30
+
+static uint32_t drag_ring_spawn[DRAG_NUM_RINGS] = {0};
+static uint8_t  drag_ring_slot   = 0;
+static uint32_t drag_last_spawn  = 0;
+static uint32_t drag_last_frame  = 0;
+static bool     drag_prev        = false;
+static bool     drag_ui_rendered = false;
+
+static inline void drag_plot(int16_t x, int16_t y) {
+    if ((uint16_t)x < 128 && (uint16_t)y < 32) {
+        oled_write_pixel((uint8_t)x, (uint8_t)y, true);
+    }
+}
+
+static void draw_ring_dissipating(int16_t cx, int16_t cy, int16_t r, uint8_t alive_pct) {
+    if (r <= 0) return;
+    int16_t x   = r;
+    int16_t y   = 0;
+    int16_t err = 1 - r;
+    while (x >= y) {
+        if ((fast_rand() % 100) < alive_pct) drag_plot(cx + x, cy + y);
+        if ((fast_rand() % 100) < alive_pct) drag_plot(cx + y, cy + x);
+        if ((fast_rand() % 100) < alive_pct) drag_plot(cx - y, cy + x);
+        if ((fast_rand() % 100) < alive_pct) drag_plot(cx - x, cy + y);
+        if ((fast_rand() % 100) < alive_pct) drag_plot(cx - x, cy - y);
+        if ((fast_rand() % 100) < alive_pct) drag_plot(cx - y, cy - x);
+        if ((fast_rand() % 100) < alive_pct) drag_plot(cx + y, cy - x);
+        if ((fast_rand() % 100) < alive_pct) drag_plot(cx + x, cy - y);
+        y++;
+        if (err <= 0) {
+            err += 2 * y + 1;
+        } else {
+            x--;
+            err += 2 * (y - x) + 1;
+        }
+    }
+}
+
+static bool drag_has_live_rings(void) {
+    for (uint8_t i = 0; i < DRAG_NUM_RINGS; i++) {
+        if (drag_ring_spawn[i] != 0 &&
+            timer_elapsed32(drag_ring_spawn[i]) < DRAG_RING_LIFETIME_MS) {
+            return true;
+        }
+    }
+    return false;
+}
+
 oled_rotation_t oled_init_user(oled_rotation_t rotation) {
     oled_startup_timer = timer_read32();
     oled_startup_complete = false;
@@ -380,6 +439,52 @@ bool oled_task_user(void) {
     // (process_record_user only runs on master, so slave OLED needs this)
     if ((screensaver_active || screen_is_off) && last_input_activity_elapsed() < 1000) {
         register_oled_activity();
+    }
+
+    // Drag sonar ping — takes precedence over screensaver and layer-4 freeze.
+    // Keeps rendering after drag_active drops until in-flight rings fade out.
+    bool drag_ui_active = drag_active || drag_has_live_rings();
+    if (drag_ui_active) {
+        if (screen_is_off) { screen_is_off = false; oled_on(); }
+        if (screensaver_active) { screensaver_active = false; warp_initialized = false; }
+        last_activity_time = timer_read32();
+
+        if (drag_active && !drag_prev) {
+            for (uint8_t i = 0; i < DRAG_NUM_RINGS; i++) drag_ring_spawn[i] = 0;
+            drag_ring_slot  = 0;
+            drag_last_spawn = 0;
+        }
+        drag_prev = drag_active;
+
+        if (timer_elapsed32(drag_last_frame) >= DRAG_FRAME_MS) {
+            drag_last_frame = timer_read32();
+
+            if (drag_active && (drag_last_spawn == 0 ||
+                timer_elapsed32(drag_last_spawn) >= DRAG_RING_SPAWN_MS)) {
+                drag_ring_spawn[drag_ring_slot] = timer_read32();
+                drag_ring_slot = (drag_ring_slot + 1) % DRAG_NUM_RINGS;
+                drag_last_spawn = timer_read32();
+            }
+
+            oled_clear();
+            for (uint8_t i = 0; i < DRAG_NUM_RINGS; i++) {
+                if (drag_ring_spawn[i] == 0) continue;
+                uint32_t age = timer_elapsed32(drag_ring_spawn[i]);
+                if (age >= DRAG_RING_LIFETIME_MS) { drag_ring_spawn[i] = 0; continue; }
+                int16_t r = (int16_t)((age * DRAG_RING_MAX_RADIUS) / DRAG_RING_LIFETIME_MS);
+                uint8_t alive = 100 - (uint8_t)((age * 100) / DRAG_RING_LIFETIME_MS);
+                draw_ring_dissipating(SCREEN_CENTER_X, SCREEN_CENTER_Y, r, alive);
+            }
+        }
+        drag_ui_rendered = true;
+        return false;
+    }
+    drag_prev = drag_active;
+
+    // Drag just ended and rings are gone — wipe leftover pixels before normal render
+    if (drag_ui_rendered) {
+        oled_clear();
+        drag_ui_rendered = false;
     }
 
     if (!screensaver_active && timer_elapsed32(last_activity_time) > SCREENSAVER_TIMEOUT) {

--- a/keyboards/hidpress/bipedalambi/bipedalambi.h
+++ b/keyboards/hidpress/bipedalambi/bipedalambi.h
@@ -15,6 +15,7 @@ extern enum pointing_device_mode current_mode;
 extern int actuation;
 extern bool showing_actuation;
 extern uint32_t actuation_display_timer;
+extern bool drag_active;
 
 void register_oled_activity(void);
 

--- a/keyboards/hidpress/bipedalambi/keymaps/vial/keymap.c
+++ b/keyboards/hidpress/bipedalambi/keymaps/vial/keymap.c
@@ -22,6 +22,7 @@ void joystick_sync_slave_handler(uint8_t in_buflen, const void *in_data, uint8_t
 typedef struct {
     uint8_t mode;
     uint8_t actuation_index;
+    uint8_t drag;
 } state_sync_t;
 
 // state_sync_slave_handler defined below after variable declarations
@@ -50,6 +51,7 @@ uint8_t current_actuation_index = 2;
 void state_sync_slave_handler(uint8_t in_buflen, const void *in_data, uint8_t out_buflen, void *out_data) {
     const state_sync_t *state = (const state_sync_t *)in_data;
     current_mode = state->mode;
+    drag_active  = (state->drag != 0);
     if (state->actuation_index != current_actuation_index) {
         current_actuation_index = state->actuation_index;
         actuation = actuation_values[state->actuation_index];
@@ -452,6 +454,7 @@ void housekeeping_task_user(void) {
             state_sync_t state = {
                 .mode = current_mode,
                 .actuation_index = current_actuation_index,
+                .drag = drag_active ? 1 : 0,
             };
             transaction_rpc_send(USER_SYNC_STATE, sizeof(state), &state);
             last_state_sync = timer_read32();
@@ -538,6 +541,7 @@ report_mouse_t pointing_device_task_user(report_mouse_t mouse_report) {
                 } else if (has_movement) {
                     dth_state      = DTH_DRAG_ACTIVE;
                     dth_idle_count = 0;
+                    drag_active    = true;
                     mouse_report.buttons |= MOUSE_BTN1;
                 }
                 break;
@@ -548,7 +552,8 @@ report_mouse_t pointing_device_task_user(report_mouse_t mouse_report) {
                     dth_idle_count++;
                 }
                 if (dth_idle_count > DTH_RELEASE_COUNT) {
-                    dth_state = DTH_IDLE;
+                    dth_state   = DTH_IDLE;
+                    drag_active = false;
                 } else {
                     mouse_report.buttons |= MOUSE_BTN1;
                 }

--- a/keyboards/hidpress/bipedalambi/keymaps/vial/keymap.c
+++ b/keyboards/hidpress/bipedalambi/keymaps/vial/keymap.c
@@ -448,9 +448,13 @@ void matrix_scan_user(void) {
 // --- Housekeeping Task (Split Transport Polling) ---
 void housekeeping_task_user(void) {
     if (is_keyboard_master()) {
-        // Sync state (current_mode) to slave for OLED display
+        // Sync state (current_mode) to slave for OLED display.
+        // Edge-triggered when drag_active flips so the slave sees brief drags
+        // that would otherwise fall between 10Hz periodic syncs.
         static uint32_t last_state_sync = 0;
-        if (timer_elapsed32(last_state_sync) > 100) {  // 10Hz — OLED doesn't need faster
+        static bool     last_drag_sent  = false;
+        bool drag_edge = (drag_active != last_drag_sent);
+        if (drag_edge || timer_elapsed32(last_state_sync) > 100) {
             state_sync_t state = {
                 .mode = current_mode,
                 .actuation_index = current_actuation_index,
@@ -458,6 +462,7 @@ void housekeeping_task_user(void) {
             };
             transaction_rpc_send(USER_SYNC_STATE, sizeof(state), &state);
             last_state_sync = timer_read32();
+            last_drag_sent  = drag_active;
         }
 
         // When right is master, poll joystick ADC from left (slave) via split transport


### PR DESCRIPTION
## Summary
- Emits a pulsating sonar-ping ring from the OLED center whenever the trackpad double-tap-hold drag is active on `hidpress/bipedalambi`.
- Each ring expands outward past the screen edges while dissipating (pixels drop probabilistically as the ring ages), producing a radar/sonar feel. After release, in-flight rings finish their expansion then normal layer rendering resumes.
- New `drag_active` flag is set by the DTH state machine in the vial keymap and synced to the slave half via the existing `USER_SYNC_STATE` RPC, so the effect appears regardless of which half is USB master. The render path takes precedence over both the screensaver and the layer-4 auto-mouse freeze.

## Test plan
- [ ] Flash both halves (`make hidpress/bipedalambi:vial` and `SIDE=right`) and confirm the firmware builds cleanly.
- [ ] Tap-then-drag on the trackpad; verify rings emanate from OLED center and fade past the edges.
- [ ] Release the drag; verify in-flight rings finish and the normal layer view returns without leftover pixels.
- [ ] Trigger drag while the screensaver is running; confirm the OLED wakes into the sonar animation.
- [ ] Trigger drag while on the auto-mouse layer (4); confirm the animation plays (overrides the freeze).
- [ ] Swap USB master to the opposite half and repeat the checks to confirm the split state sync works both directions.

https://claude.ai/code/session_019axSTYHAHZbegsAqxYAxUY

---
_Generated by [Claude Code](https://claude.ai/code/session_019axSTYHAHZbegsAqxYAxUY)_